### PR TITLE
Automatically publish the package on new release tag

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,33 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm ci
+      - run: npm test
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/npm-version.yml
+++ b/.github/workflows/npm-version.yml
@@ -1,0 +1,37 @@
+﻿name: Increment Version
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: 'Version Type'     
+        required: true
+        default: 'patch'
+        type: 'choice'
+        options:
+        - major
+        - premajor
+        - minor
+        - preminor
+        - patch
+        - prepatch
+        - prerelease
+      message:
+        description: 'Commit Message'
+        required: true
+        default: 'Upgrade to %s'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Increment Version
+        run: npm version $VERSION_TYPE -m "$MESSAGE"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# YATSL
+# YATSL ![Test Status](https://github.com/towergame/yatsl/actions/workflows/testing.yml/badge.svg)  
 *(**Y**et **A**nother **T**ype**S**cript **L**ogger)*  
     
+
 **What is this?**  
 A logger utility that *should* be relatively simple/quick to set up and offers a neat output. It's also not anything fancy, it will not connect to 5 different servers and upload the log to the blockchain or something, but it should be sufficient for debug logging or just in general having an idea what your typescript program is doing.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yatsl",
-  "version": "1.2.1",
+  "version": "1.2.0",
   "description": "A simple logger utility for typescript with colourful ANSI output.",
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yatsl",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A simple logger utility for typescript with colourful ANSI output.",
   "files": [
     "dist"


### PR DESCRIPTION
Adds GitHub Actions for publishing whenever a new release tag is made and an action to run `npm version` from GitHub.