### PR TITLE
Config option overrides for a single call

### DIFF
--- a/docs/Basic Setup.md
+++ b/docs/Basic Setup.md
@@ -41,3 +41,14 @@ This allows for fine-tuning of log options during creation of the logger. It sho
 | decimalDigits | number			   | Defines how many digits to render after the comma for numbers passed to the logger. |
 | multilineObjects | boolean			   | Whether to output object JSON representations in multiple lines or a single one, if the logger is given multiple values to log, objects will always be rendered in a single line. |
 | tabs | boolean			   | Whether to use tabs (true) or spaces (false) for multi-line JSON. |
+
+# Overriding the Config for a Single Call
+The config can also be overriden for a single call through the use of `logger.overrideConfig`, by passing it a config object with some of the options above, the logger will use these options for the next call. After the call, it will return to its usual options defined in the `config` field.
+```ts
+
+import { logger } from "yatsl";
+
+logger.overrideConfig({minLevel: LogLevel.CRITICAL});
+logger.info("Hello World!"); // Will not be logged
+logger.info("Hello World!"); // Will be logged
+```

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -707,3 +707,81 @@ describe("Logging an object with tabs set to false", () => {
 		return chai.expect(testStream.read().toString()).to.match(/\s/);
 	});
 });
+
+describe("Logging with an option override setting minLevel to EMERGENCY", () => {
+	// Set up the logger
+	let testStream = new stream.PassThrough();
+	let logger = new Logger({
+		streams: [{ stream: testStream, color: true }] // Creates a logger with default settings, except logs it to our custom stream for testing
+	});
+	it("DEBUG should log once", () => {
+		// Log a test message
+		logger.overrideConfig({ minLevel: LogLevel.EMERGENCY });
+		logger.debug("This is a test.");
+		let a = testStream.read();
+		logger.debug("This is a test.");
+		let b = testStream.read();
+
+		return chai.expect(a).to.equal(null).but.not.equal(b);
+	});
+	it("INFO should log once", () => {
+		// Log a test message
+		logger.overrideConfig({ minLevel: LogLevel.EMERGENCY });
+		logger.info("This is a test.");
+		let a = testStream.read();
+		logger.info("This is a test.");
+		let b = testStream.read();
+
+		return chai.expect(a).to.equal(null).but.not.equal(b);
+	});
+	it("NOTICE should log once", () => {
+		// Log a test message
+		logger.overrideConfig({ minLevel: LogLevel.EMERGENCY });
+		logger.note("This is a test.");
+		let a = testStream.read();
+		logger.note("This is a test.");
+		let b = testStream.read();
+
+		return chai.expect(a).to.equal(null).but.not.equal(b);
+	});
+	it("WARNING should log once", () => {
+		// Log a test message
+		logger.overrideConfig({ minLevel: LogLevel.EMERGENCY });
+		logger.warn("This is a test.");
+		let a = testStream.read();
+		logger.warn("This is a test.");
+		let b = testStream.read();
+
+		return chai.expect(a).to.equal(null).but.not.equal(b);
+	});
+	it("ERROR should log once", () => {
+		// Log a test message
+		logger.overrideConfig({ minLevel: LogLevel.EMERGENCY });
+		logger.error("This is a test.");
+		let a = testStream.read();
+		logger.error("This is a test.");
+		let b = testStream.read();
+
+		return chai.expect(a).to.equal(null).but.not.equal(b);
+	});
+	it("CRITICAL should log once", () => {
+		// Log a test message
+		logger.overrideConfig({ minLevel: LogLevel.EMERGENCY });
+		logger.critical("This is a test.");
+		let a = testStream.read();
+		logger.critical("This is a test.");
+		let b = testStream.read();
+
+		return chai.expect(a).to.equal(null).but.not.equal(b);
+	});
+	it("ALERT should log once", () => {
+		// Log a test message
+		logger.overrideConfig({ minLevel: LogLevel.EMERGENCY });
+		logger.alert("This is a test.");
+		let a = testStream.read();
+		logger.alert("This is a test.");
+		let b = testStream.read();
+
+		return chai.expect(a).to.equal(null).but.not.equal(b);
+	});
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,7 +227,10 @@ export class Logger {
 	 */
 	private write(rawMessage: any[], severity: LogLevel) {
 		let actualConfig = { ...this.config, ...this.override };
-		if ((actualConfig.minLevel !== null || actualConfig.minLevel !== undefined) && actualConfig.minLevel! < severity) return;
+		if ((actualConfig.minLevel !== null || actualConfig.minLevel !== undefined) && actualConfig.minLevel! < severity) {
+			this.override = {};
+			return;
+		}
 
 		let message = rawMessage.length > 0 ? this.stringify(rawMessage, actualConfig) : "";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,8 @@ export class Logger {
 		tabs: true,
 	}
 
+	private override: LoggerConfig = {};
+
 	constructor(conf?: LoggerConfig) {
 		if (conf) this.config = { ...this.config, ...conf };
 	}
@@ -141,11 +143,19 @@ export class Logger {
 	 * Log a message with the severity of DEBUG
 	 * @param data String(s) to log
 	 */
-	public debug(...data: any[]) {
+	public debug(...data: any[]): void {
 		this.write(data, LogLevel.DEBUG);
 	}
 
-	public log(...data: any[]) { this.debug(...data) };
+	public log(first: any, ...data: any[]) { this.debug(first, ...data) };
+
+	/**
+	 * Temporarily overrides config options for the next call.
+	 * @param config Config values to override for next call
+	 */
+	public overrideConfig(config: LoggerConfig) {
+		this.override = config; // TODO: Figure out how to make config overrides passable to logger.debug, etc.
+	}
 
 	// Shamelessly stolen from a friend.
 	private getCallSignature(): string {
@@ -175,12 +185,12 @@ export class Logger {
 	 * @param content The array to be stringified
 	 * @returns A JSON string of content
 	 */
-	private stringify(content: any[], recursive: boolean = false): string {
+	private stringify(content: any[], actualConfig: LoggerConfig, recursive: boolean = false): string {
 		let result = "";
 		if (content.length > 1) {
 			// result += "[ ";
 			for (let x: number = 0; x < content.length; x++) {
-				result += this.stringify([content[x]], true);
+				result += this.stringify([content[x]], actualConfig, true);
 				if (x + 1 !== content.length) result += " | ";
 			}
 			// result += " ]";
@@ -193,16 +203,16 @@ export class Logger {
 					result = content[0];
 					break;
 				case "number":
-					result = (content[0] as number).toFixed(content[0] % 1 > 0 ? this.config.decimalDigits : 0);
+					result = (content[0] as number).toFixed(content[0] % 1 > 0 ? actualConfig.decimalDigits : 0);
 					break;
 				case "boolean":
 					result = content[0].toString();
 					break;
 				default:
-					if (recursive || !this.config.multilineObjects) {
+					if (recursive || !actualConfig.multilineObjects) {
 						result = JSON.stringify(content[0]);
 					} else {
-						result = "\n" + JSON.stringify(content[0], null, this.config.tabs ? '\t' : '\s\s');
+						result = "\n" + JSON.stringify(content[0], null, actualConfig.tabs ? '\t' : '\s\s');
 					}
 					result = this.highlightJSON(result);
 			}
@@ -216,9 +226,10 @@ export class Logger {
 	 * @param severity The severity of log
 	 */
 	private write(rawMessage: any[], severity: LogLevel) {
-		if ((this.config.minLevel !== null || this.config.minLevel !== undefined) && this.config.minLevel! < severity) return;
+		let actualConfig = { ...this.config, ...this.override };
+		if ((actualConfig.minLevel !== null || actualConfig.minLevel !== undefined) && actualConfig.minLevel! < severity) return;
 
-		let message = rawMessage.length > 0 ? this.stringify(rawMessage) : "";
+		let message = rawMessage.length > 0 ? this.stringify(rawMessage, actualConfig) : "";
 
 		let style = "";
 		switch (severity) {
@@ -248,15 +259,17 @@ export class Logger {
 				break;
 		}
 		let line = "";
-		if (this.config.logLine) line += " | " + this.getCallSignature();
-		if (this.config.name !== "") line += " | " + this.config.name;
+		if (actualConfig.logLine) line += " | " + this.getCallSignature();
+		if (actualConfig.name !== "") line += " | " + actualConfig.name;
 
 		const ansiLogStr = `\x1b[2m${(new Date()).toISOString()}${reset} [${style}${reset}${line}] ${message}\n`;
 		const rawLogStr = stripAnsi(ansiLogStr);
 
-		this.config.streams?.forEach((stream) => {
+		actualConfig.streams?.forEach((stream) => {
 			stream.stream.write(stream.color ? ansiLogStr : rawLogStr);
 		});
+
+		this.override = {}; // Clear the override
 	}
 }
 


### PR DESCRIPTION
Adds `overrideConfig` function that allows the user to override config options for a single call, upon which it gets reverted.