### PR TITLE
Cyclic object basic logging handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -215,12 +215,21 @@ export class Logger {
 					result = content[0].toString();
 					break;
 				default:
-					if (recursive || !actualConfig.multilineObjects) {
-						result = JSON.stringify(content[0]);
-					} else {
-						result = "\n" + JSON.stringify(content[0], null, actualConfig.tabs ? '\t' : '\s\s');
+					try {
+						if (recursive || !actualConfig.multilineObjects) {
+							result = JSON.stringify(content[0]);
+						} else {
+							result = "\n" + JSON.stringify(content[0], null, actualConfig.tabs ? '\t' : '\s\s');
+						}
+						result = this.highlightJSON(result);
+					} catch (err) {
+						if(err instanceof TypeError) {
+							result = "[ unserializable object ]";
+						} else {
+							throw err;
+						}
 					}
-					result = this.highlightJSON(result);
+					
 			}
 		}
 		return result;

--- a/src/object.spec.ts
+++ b/src/object.spec.ts
@@ -102,3 +102,25 @@ describe("Logging an object with tabs set to false", () => {
 		return chai.expect(testStream.read().toString()).to.match(/ /);
 	});
 });
+
+describe("Logging unseriazable objects", () => {
+	let testStream = new stream.PassThrough();
+	let logger = new Logger({
+		minLevel: LogLevel.DEBUG,
+		streams: [{ stream: testStream, color: true }] // Creates a logger with default settings, except logs it to our custom stream for testing
+	});
+	it("logs [ unserializable object ] when passing an object referencing self", () => {
+		let obj: any = {};
+		obj.obj = obj;
+		logger.log(obj);
+		return chai.expect(testStream.read().toString()).to.match(/\[ unserializable object \]/);
+	});
+	it("logs [ unserializable object ] when passing objects referencing each other", () => {
+		let obj1: any = {};
+		let obj2: any = {};
+		obj1.obj = obj2;
+		obj2.obj = obj1;
+		logger.log(obj1);
+		return chai.expect(testStream.read().toString()).to.match(/\[ unserializable object \]/);
+	});
+});


### PR DESCRIPTION
Upon detecting an unserializable object (object has circular references or it contains big integers) prints `[ unserializable object ]` instead of throwing.
This serves as a simple bandaid solution to #26
Because JSON lacks some aspects of what a javascript object can contain, A complete replacement of `JSON.stringify` is in order.
