### PR TITLE
Stringify rewrite

### DIFF
--- a/docs/Basic Setup.md
+++ b/docs/Basic Setup.md
@@ -41,6 +41,7 @@ This allows for fine-tuning of log options during creation of the logger. It sho
 | decimalDigits | number			   | Defines how many digits to render after the comma for numbers passed to the logger. |
 | multilineObjects | boolean			   | Whether to output object JSON representations in multiple lines or a single one, if the logger is given multiple values to log, objects will always be rendered in a single line. |
 | tabs | boolean			   | Whether to use tabs (true) or spaces (false) for multi-line JSON. |
+| carriageReturn | boolean | Whether to use \<CR\> before the newline characters. Useful for older or more basic consoles. False by default. |
 
 # Overriding the Config for a Single Call
 The config can also be overriden for a single call through the use of `logger.overrideConfig`, by passing it a config object with some of the options above, the logger will use these options for the next call. After the call, it will return to its usual options defined in the `config` field.

--- a/src/index.ts
+++ b/src/index.ts
@@ -270,22 +270,19 @@ export class Logger {
 	 * @param content The array to be stringified
 	 * @returns A JSON string of content
 	 */
-	private stringify(content: any[], actualConfig: LoggerConfig, recursive: boolean = false): string {
+	private stringify(content: any[], actualConfig: LoggerConfig): string {
 		let references: any[] = [];
 		let result = "";
 		if (content.length === 0) {
-			if(recursive) {
-				result = "[ ]";
-				/* If we're given an empty array, just return "[ ]" to indicate that it's empty.
-				Hopefully that's what the user wanted and there isn't a horrible bug that passes an empty array to this function. */
-			} else {
-				result = "";
-				/* If this isn't the top level call, we don't want to return anything.
-				It could be useful for just printing a timestamp or something. */
-			}
+			result = "";
+			// an empty array means that the user just called logger.log() with no arguments.
+			// we don't want to log anything in this case.
+			// the timestamp and line number will still be printed, though.
 		} else if (content.length === 1) {
 			result = this.stringifyItem(content[0], actualConfig, references, 0);
 		} else if (content.length > 1) {
+			// disable multilineObjects for multiple items
+			actualConfig.multilineObjects = false;
 			// result += "[ ";
 			for (let x: number = 0; x < content.length; x++) {
 				result += this.stringifyItem(content[x], actualConfig, references, 0);

--- a/src/index.ts
+++ b/src/index.ts
@@ -222,7 +222,7 @@ export class Logger {
 				break;
 			case "symbol":
 				// TODO: Figure out how to stringify symbols, whatever that means
-				result = "[symbol]";
+				result = item.toString();
 				break;
 			case "function":
 				// differentiate function from class
@@ -230,7 +230,7 @@ export class Logger {
 					let hasNonTrivialReferences = false;
 					for(let i=0;i<referenceArr.length;i++) {
 						if(referenceArr[i][0] === item && depth > referenceArr[i][1]) {
-							result = "[unserializable object]";
+							result = "[circular reference]";
 							hasNonTrivialReferences = true;
 							break;
 						}
@@ -255,7 +255,7 @@ export class Logger {
 					let hasNonTrivialReferences = false;
 					for(let i=0;i<referenceArr.length;i++) {
 						if(referenceArr[i][0] === item && depth > referenceArr[i][1]) {
-							result = "[unserializable object]";
+							result = "[circular reference]";
 							hasNonTrivialReferences = true;
 							referenceArr[i][1] = depth;
 							break;

--- a/src/index.ts
+++ b/src/index.ts
@@ -230,7 +230,7 @@ export class Logger {
 					let hasNonTrivialReferences = false;
 					for(let i=0;i<referenceArr.length;i++) {
 						if(referenceArr[i][0] === item && depth > referenceArr[i][1]) {
-							result = "[circular reference]";
+							result = "[non-trivial reference]";
 							hasNonTrivialReferences = true;
 							break;
 						}
@@ -255,7 +255,7 @@ export class Logger {
 					let hasNonTrivialReferences = false;
 					for(let i=0;i<referenceArr.length;i++) {
 						if(referenceArr[i][0] === item && depth > referenceArr[i][1]) {
-							result = "[circular reference]";
+							result = "[non-trivial reference]";
 							hasNonTrivialReferences = true;
 							referenceArr[i][1] = depth;
 							break;

--- a/src/stringification.spec.ts
+++ b/src/stringification.spec.ts
@@ -78,6 +78,6 @@ describe("Logging a complex object with default settings", () => {
 	});
 	it("logging circular reference", () => {
 		console.log(str);
-		return chai.expect(str).to.contain("\"funny\": [circular reference]");
+		return chai.expect(str).to.contain("\"funny\": [non-trivial reference]");
 	});
 });

--- a/src/stringification.spec.ts
+++ b/src/stringification.spec.ts
@@ -41,27 +41,43 @@ describe("Logging a complex object with default settings", () => {
 	};
     testObject["funny"] = testObject;
     logger.log(testObject);
-    const str = testStream.read().toString();
+    const str: string = testStream.read().toString();
 
 	it("logging string types", () => {
-		return chai.expect(str).to.contain("\"text\": \"string with some characters\",");
+		return chai.expect(str).to.contain("\"text\": \"string with some characters\"");
 	});
     it("logging undefined", () => {
-		return chai.expect(str).to.contain("\"undef\": undefined,");
+		return chai.expect(str).to.contain("\"undef\": undefined");
 	});
     it("logging null", () => {
-		return chai.expect(str).to.contain("\"null\": null,");
+		return chai.expect(str).to.contain("\"null\": null");
 	});
     it("logging number", () => {
-		return chai.expect(str).to.contain("\"number\": 1,");
+		return chai.expect(str).to.contain("\"number\": 1");
 	});
     it("logging bool", () => {
-		return chai.expect(str).to.contain("\"boolean\": true,");
+		return chai.expect(str).to.contain("\"boolean\": true");
 	});
     it("logging arr", () => {
-		return chai.expect(str).to.match(/"array":\s+\[\s+1,\s+"he",\s+3\s+\],/);
+		return chai.expect(str).to.match(/"array":\s+\[\s+1,\s+"he",\s+3\s+\]/);
 	});
     it("logging function", () => {
-        return chai.expect(str).to.contain("\"fun\": [Function fun2],");
+        return chai.expect(str).to.contain("\"fun\": [Function fun2]");
     });
+	it("logging symbol", () => {
+		return chai.expect(str).to.contain("\"symbol\": Symbol(test)");
+	});
+	it("logging bigint", () => {
+		return chai.expect(str).to.contain("\"bigint\": 153424234");
+	});
+	it("logging class", () => {
+		return chai.expect(str).to.contain("\"s\": [Class S]");
+	});
+	it("logging class instance", () => {
+		return chai.expect(str).to.match(/"s_instance":\s*S\s*\{\s*"_de"\s*:\s*"de"\s*\}/g);
+	});
+	it("logging circular reference", () => {
+		console.log(str);
+		return chai.expect(str).to.contain("\"funny\": [circular reference]");
+	});
 });

--- a/src/stringification.spec.ts
+++ b/src/stringification.spec.ts
@@ -1,0 +1,67 @@
+import stream from 'stream';
+import { Logger, LogLevel } from './index';
+import * as chai from 'chai';
+import 'mocha';
+
+describe("Logging a complex object with default settings", () => {
+	// Set up the logger
+	let testStream = new stream.PassThrough();
+	let logger = new Logger({
+		streams: [{ stream: testStream, color: false }], // Creates a logger with default settings, except logs it to our custom stream for testing
+
+	});
+    class S {
+        private _de: string;
+        constructor() {
+            this._de = "de";
+        }
+        get de() {
+            return this._de;
+        }
+    }
+	let testObject = {
+		text: "string with some characters",
+        undef: undefined,
+        null: null,
+        number: 1,
+        boolean: true,
+        array: [1, "he", 3],
+        object: {
+            text: "string with some characters",
+        },
+        fun: function fun2() {
+            const hehe=69;
+            return hehe;
+        },
+        symbol: Symbol("test"),
+        bigint: BigInt(153424234),
+        s: S,
+        s_instance: new S(),
+        funny: {} 
+	};
+    testObject["funny"] = testObject;
+    logger.log(testObject);
+    const str = testStream.read().toString();
+
+	it("logging string types", () => {
+		return chai.expect(str).to.contain("\"text\": \"string with some characters\",");
+	});
+    it("logging undefined", () => {
+		return chai.expect(str).to.contain("\"undef\": undefined,");
+	});
+    it("logging null", () => {
+		return chai.expect(str).to.contain("\"null\": null,");
+	});
+    it("logging number", () => {
+		return chai.expect(str).to.contain("\"number\": 1,");
+	});
+    it("logging bool", () => {
+		return chai.expect(str).to.contain("\"boolean\": true,");
+	});
+    it("logging arr", () => {
+		return chai.expect(str).to.match(/"array":\s+\[\s+1,\s+"he",\s+3\s+\],/);
+	});
+    it("logging function", () => {
+        return chai.expect(str).to.contain("\"fun\": [Function fun2],");
+    });
+});


### PR DESCRIPTION
I've done an overhaul on stringification as the previous versions used JSON.stringify, which is unable to handle functions or classes or class instances, as well as `bigint`s. It also allows for logging circular references, and it will attempt to display as much as possible without repeating data.
Additionally a carriage return option has been added to config and the documentation. ( off by default of course :) )
This could close #32 #26 and make #31 obsolete should this PR be merged faster.

